### PR TITLE
Disable default token upgrades.

### DIFF
--- a/src/Request.ts
+++ b/src/Request.ts
@@ -9,7 +9,7 @@ class Request {
   private body: string = "{}";
   private contentType: string = "application/json; charset=UTF-8";
   private authRequired: boolean = true;
-  private upgradeRequired: boolean = true;
+  private upgradeRequired: boolean = false;
   private checkRequestStatus: boolean | null = null;
   private headers: object = {};
 

--- a/test/unit/Request.test.ts
+++ b/test/unit/Request.test.ts
@@ -34,7 +34,7 @@ describe("Request", () => {
     request.setAuthRequired(false);
     expect(request.isAuthRequired()).toBeFalsy();
 
-    expect(request.isUpgradeRequired()).toBeTruthy();
+    expect(request.isUpgradeRequired()).toBeFalsy();
     request.setUpgradeRequired(false);
     expect(request.isUpgradeRequired()).toBeFalsy();
 


### PR DESCRIPTION
The recent change on GM's side disabled the existing auth flow. After @joelvandal determined the upgrade was no longer being called I tried defaulting `upgradeRequired` to false and my library, onstar2mqtt, was able to make a diagnostic request.

Should fix #214. The functional test gives me a 403 on cancelAlert, however that may be due to my OnStar remote commands plan expiring.