### PR TITLE
Bypass Firebase App-Check

### DIFF
--- a/src/onStarAppConfig.json
+++ b/src/onStarAppConfig.json
@@ -1,8 +1,8 @@
 {
-  "appId": "OMB_CVY_AND_6P1",
-  "appSecret": "5y6MRMJbMG2yVUG7dhAbbXjsCZCNDXtMt6oR",
+  "appId": "OMB_CVY_iOS_6S0",
+  "appSecret": "53YJ67kyLqMCzVEb758ySwXYxCThn7eeLw3D",
   "optionalClientScope": "",
   "requiredClientScope": "onstar gmoc user_trailer user priv",
   "serviceUrl": "https://api.gm.com",
-  "userAgent": "Mozilla/5.0 (Linux; U; Android 9; en-US; Google Pixel 2 Build/PI)"
+  "userAgent": "myChevrolet/73 CFNetwork/1408.0.4 Darwin/22.5.0"
 }


### PR DESCRIPTION
I would like to contribute the results of my research on OnStar's recent addition of Firebase App-Check.

As I explained in the issue (#233), each client credential pair likely has their own rules applied to them. This is the case for 
the iOS credentials as well. They are configured in a way that Firebase App-Check is not required.

Simply switching to the iOS client credentials & user agent should make your library work again. In my local test I was able to run functional tests again.

This change also means that in the future, you would need to source your credential pair from the iOS app.