### PR TITLE
Include shared vehicles in getAccountVehicles

### DIFF
--- a/src/RequestService.ts
+++ b/src/RequestService.ts
@@ -211,7 +211,7 @@ class RequestService {
     const request = new Request(
       `${this.getApiUrlForPath(
         "/account/vehicles",
-      )}?includeCommands=true&includeEntit%20lements=true&includeModules=true`,
+      )}?includeCommands=true&includeEntitlements=true&includeModules=true&includeSharedVehicles=true`,
     )
       .setUpgradeRequired(false)
       .setMethod(RequestMethod.Get);


### PR DESCRIPTION
Fixes #204.
I also removed a random space from `includeEntitlements`.
This should be tested on a account with no shared vehicles.